### PR TITLE
feat(alerts): telegram drop rules

### DIFF
--- a/configs/config.go
+++ b/configs/config.go
@@ -41,6 +41,7 @@ type Config struct {
 			IsEnabled bool                      `yaml:"enable"`
 			Host      string                    `yaml:"host"`
 			Token     string                    `yaml:"token"`
+			Drop      []string                  `yaml:"drop"`
 			Teams     map[string][]TelegramTeam `yaml:"teams"`
 		} `yaml:"telegram"`
 		Slack struct {

--- a/configs/config.yml.example
+++ b/configs/config.yml.example
@@ -33,6 +33,8 @@ notifier:
     enable: true
     host: "https://api.telegram.org/bot"
     token: "1234:ABCD"
+    drop_rules:
+      - new_api_v2_alert
     teams:
       team1:
         - chat: "-123456789"

--- a/internal/platform/repositories/alert/telegram.go
+++ b/internal/platform/repositories/alert/telegram.go
@@ -28,8 +28,17 @@ func (r *Repository) CreateTelegramMessage(alert models.Alert) error {
 			params := url.Values{}
 			params.Add("chat_id", t.Chat)
 			params.Add("parse_mode", "markdownv2")
-			if t.Topic != "" {
-				params.Add("message_thread_id", t.Topic)
+			// Don't send message if the the topic is matched to any dropped rules.
+			if len(r.config.Notifier.Telegram.Drop) > 0 {
+				for _, rule := range r.config.Notifier.Telegram.Drop {
+					if rule != t.Topic && t.Topic != "" {
+						params.Add("message_thread_id", t.Topic)
+					}
+				}
+			} else {
+				if t.Topic != "" {
+					params.Add("message_thread_id", t.Topic)
+				}
 			}
 			url := r.config.Notifier.Telegram.Host + r.config.Notifier.Telegram.Token + "/sendMessage?" + params.Encode()
 			urls = append(urls, url)


### PR DESCRIPTION
Hello @hatamiarash7

This PR gets an optional `Drop` entry filed as a `[]string`, and when the app wants to send alerts in Telegram channels, it first checks the slice, and if the alert matches with any item inside that slice, it simply drops it.